### PR TITLE
General Cleanup and some Library routes added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 sw.*
 .DS_STORE
 .idea/*
+
+wiretap-report.json
+build-docs/report.html

--- a/build-docs/api_runner.py
+++ b/build-docs/api_runner.py
@@ -20,6 +20,7 @@ def write_to_json(fname, data):
 # Server specific information
 server_ip = "http://localhost"
 server_port = 9090
+#server_port = 3333
 
 ###########################
 ### Setup
@@ -215,7 +216,7 @@ def delete_collections(id):
   # Delete response
   r = requests.delete(url = url, headers = HEADERS)
 
-if True:
+if False:
   resp = create_collection(library_ids[0], "First None", None, None)
   descriptions = [None, "First description", "Hello, here we go with some extra things."]
   book_arrs    = [None, [books[0]], books[1:3], books[3:7]]
@@ -274,3 +275,121 @@ if True:
   # Delete all collections
   for collection in collections:
     delete_collections(collection)
+  
+# This function attempts to create a library, performs some get requests on the library,
+# then deletes the newly created library. There is no content for the library, so
+# all of the media related things should be empty.
+def create_and_delete_library(headers):
+  def create_library(name, folder):
+    url = f"{BASEURL}/api/libraries"
+  
+    params = {'name'   : name,
+              'folders': folder}
+  
+    # Post response
+    r = requests.post(url = url, headers = headers, json = params)
+  
+    data = r.json()
+    return data
+
+  def get_library(id):
+    url = f"{BASEURL}/api/libraries/{id}"
+    r = requests.get(url = url, headers = headers)
+    try:
+      return r.json()
+    except:
+      return None
+
+  def delete_library_issues(id):
+    url = f"{BASEURL}/api/libraries/{id}/issues"
+    r = requests.delete(url = url, headers = headers)
+    try:
+      return r.json()
+    except:
+      return None
+
+  def delete_library(id):
+    url = f"{BASEURL}/api/libraries/{id}"
+    r = requests.delete(url = url, headers = headers)
+    try:
+      return r.json()
+    except:
+      return None
+  
+  library_name = "Test library"
+  folders      = [{'fullPath': '/bin'}]
+
+  resp = create_library(library_name, folders)
+  print("New library")
+  print(resp)
+  time.sleep(1)
+  get_library(resp['id'])
+  get_library("bbbb")
+  time.sleep(1)
+  delete_library_issues(resp['id'])
+  delete_library_issues("aaaa")
+  time.sleep(1)
+  delete_library(resp['id'])
+  delete_library("cccc")
+
+create_and_delete_library(HEADERS)
+
+# This function performs all of the gets on a library to ensure responses are correct.
+def existing_library_gets(headers, libraryId, params=None):
+  def get_library_request(path, headers, params=None):
+    if params:
+      r = requests.get(url = path, headers = headers, params=params)
+    else:
+      r = requests.get(url = path, headers = headers)
+
+    try:
+      return r.json()
+    except:
+      return None
+
+  def get_library(libraryId):
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}", headers)
+  
+  def get_library_items(libraryId):
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers)
+    params = {'limit': 0}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'limit': 4}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'page': 1}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'limit': 4, 'page': 1}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'sort': 'media.metadata.title'}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'desc': True}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'desc': False}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'minified': True}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'minified': False}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'collapseseries': True}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+    params = {'collapseseries': False}
+    get_library_request(f"{BASEURL}/api/libraries/{libraryId}/items", headers, params)
+
+
+  get_library(libraryId)
+  get_library_items(libraryId)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/episode-downloads", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/series", headers)
+  #get_library_request(f"{BASEURL}/api/libraries/{libraryId}/series/{seriesId}", headers) TODO
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/collections", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/playlists", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/personalized", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/filterdata", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/search", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/stats", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/authors", headers)
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/narrators", headers)
+  #get_library_request(f"{BASEURL}/api/libraries/{libraryId}/matchall", headers) TODO
+  get_library_request(f"{BASEURL}/api/libraries/{libraryId}/opml", headers)
+
+existing_library_gets(HEADERS, library_ids[0])

--- a/build-docs/swagger-output.json
+++ b/build-docs/swagger-output.json
@@ -520,6 +520,150 @@
         }
       }
     },
+    "/api/libraries/{id}/episode-downloads": {
+      "get": {
+        "operationId": "getEpisodeDownloadsByLibrary",
+        "summary": "Get the episode downloads for a single library by ID",
+        "tags": [
+          "Libraries"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/libraryID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "currentDownload": {
+                      "$ref": "#/components/schemas/podcastEpisodeDownload"
+                    },
+                    "queue": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/podcastEpisodeDownload"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      }
+    },
+    "/api/libraries/{id}/items": {
+      "get": {
+        "operationId": "getLibraryItemsFromLibrary",
+        "summary": "Get media items",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/libraryID"
+          },
+          {
+            "$ref": "#/components/parameters/librarySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/librarySortDesc"
+          },
+          {
+            "$ref": "#/components/parameters/libraryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/libraryPage"
+          },
+          {
+            "name": "filterBy",
+            "in": "query",
+            "description": "Filter media items by author",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "description": "Array of library items",
+                      "items": {
+                        "$ref": "#/components/schemas/libraryItem"
+                      }
+                    },
+                    "total": {
+                      "$ref": "#/components/schemas/resultsTotal"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "sortBy": {
+                      "type": "string"
+                    },
+                    "sortDesc": {
+                      "type": "boolean"
+                    },
+                    "filterBy": {
+                      "type": "string"
+                    },
+                    "mediaType": {
+                      "$ref": "#/components/schemas/mediaType"
+                    },
+                    "minified": {
+                      "type": "boolean"
+                    },
+                    "collapseseries": {
+                      "type": "boolean"
+                    },
+                    "include": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/libraries/{id}/issues": {
+      "delete": {
+        "operationId": "deleteLibraryIssuesByID",
+        "summary": "Remove all library items that have issues in the given library.",
+        "tags": [
+          "Libraries"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/libraryID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ok200"
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      }
+    },
     "/api/libraries/{id}/collections": {
       "get": {
         "operationId": "getLibraryCollections",
@@ -693,37 +837,46 @@
         "schema": {
           "type": "string"
         }
-      }
-    },
-    "responses": {
-      "library200": {
-        "description": "OK",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/library"
-            }
-          }
+      },
+      "librarySortBy": {
+        "name": "sortBy",
+        "in": "query",
+        "description": "Sort media items by a specific field",
+        "schema": {
+          "type": "string"
         }
       },
-      "library404": {
-        "description": "Library not found or user does not have access to library.",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string",
-                  "example": "Not found"
-                }
-              }
-            }
-          }
+      "librarySortDesc": {
+        "name": "sortDesc",
+        "in": "query",
+        "description": "Whether to sort in descending order",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "libraryLimit": {
+        "name": "limit",
+        "in": "query",
+        "description": "Maximum number of items to return. If `0`, no limit will be applied.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "libraryPage": {
+        "name": "page",
+        "in": "query",
+        "description": "Page number for pagination. Only applies if a limit has been set.",
+        "schema": {
+          "type": "integer"
         }
       }
     },
     "schemas": {
+      "resultsTotal": {
+        "description": "How many results were returned",
+        "type": "integer",
+        "minimum": 0
+      },
       "backup": {
         "type": "object",
         "properties": {
@@ -763,9 +916,7 @@
             "example": "2022-11-14T0130.audiobookshelf"
           },
           "fileSize": {
-            "description": "The size (in bytes) of the backup file.",
-            "type": "integer",
-            "example": 7776983
+            "$ref": "#/components/schemas/size"
           },
           "createdAt": {
             "$ref": "#/components/schemas/createdAt"
@@ -874,6 +1025,16 @@
             "Content": "Violence"
           }
         ]
+      },
+      "size": {
+        "description": "The total size (in bytes) of the item or file.",
+        "type": "integer",
+        "example": 268824228
+      },
+      "durationSec": {
+        "description": "The total length (in seconds) of the item or file.",
+        "type": "number",
+        "example": 33854.905
       },
       "deviceInfo": {
         "type": "object",
@@ -1087,18 +1248,43 @@
           }
         }
       },
+      "oldSeriesId": {
+        "description": "The ID of series on server version 2.2.23 and before.",
+        "type": "string",
+        "format": "ser_[a-z0-9]{18}",
+        "example": "ser_o78uaoeuh78h6aoeif"
+      },
+      "newSeriesId": {
+        "type": "string",
+        "description": "The ID of series after 2.3.0.",
+        "format": "uuid",
+        "example": "e4bb1afb-4a4f-4dd6-8be0-e615d233185b"
+      },
+      "seriesId": {
+        "type": "string",
+        "description": "The ID of the series.",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/oldSeriesId"
+          },
+          {
+            "$ref": "#/components/schemas/newSeriesId"
+          }
+        ]
+      },
+      "seriesName": {
+        "description": "The name of the series.",
+        "type": "string",
+        "example": "Sword of Truth"
+      },
       "series": {
         "type": "object",
         "properties": {
           "id": {
-            "description": "The ID of the series.",
-            "type": "string",
-            "example": "ser_cabkj4jeu8be3rap4g"
+            "$ref": "#/components/schemas/seriesId"
           },
           "name": {
-            "description": "The name of the series.",
-            "type": "string",
-            "example": "Sword of Truth"
+            "$ref": "#/components/schemas/seriesName"
           },
           "description": {
             "description": "A description for the series. Will be null if there is none.",
@@ -1119,14 +1305,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "The ID of the series.",
-            "type": "string",
-            "example": "ser_cabkj4jeu8be3rap4g"
+            "$ref": "#/components/schemas/seriesId"
           },
           "name": {
-            "description": "The name of the series.",
-            "type": "string",
-            "example": "Sword of Truth"
+            "$ref": "#/components/schemas/seriesName"
           },
           "nameIgnorePrefix": {
             "description": "The name of the series with any prefix moved to the end.",
@@ -1137,8 +1319,7 @@
             "description": "The IDs of the library items in the series.",
             "type": "array",
             "items": {
-              "type": "string",
-              "example": "li_8gch9ve09orgn4fdz8"
+              "$ref": "#/components/schemas/libraryItemId"
             }
           },
           "numBooks": {
@@ -1152,14 +1333,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "The ID of the series.",
-            "type": "string",
-            "example": "ser_cabkj4jeu8be3rap4g"
+            "$ref": "#/components/schemas/seriesId"
           },
           "name": {
-            "description": "The name of the series.",
-            "type": "string",
-            "example": "Sword of Truth"
+            "$ref": "#/components/schemas/seriesName"
           },
           "nameIgnorePrefix": {
             "description": "The name of the series with any prefix moved to the end.",
@@ -1184,9 +1361,7 @@
             }
           },
           "addedAt": {
-            "description": "The time (in ms since POSIX epoch) when the series was added.",
-            "type": "integer",
-            "example": 1650621073750
+            "$ref": "#/components/schemas/addedAt"
           },
           "totalDuration": {
             "description": "The combined duration (in seconds) of all books in the series.",
@@ -1199,14 +1374,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "The ID of the series.",
-            "type": "string",
-            "example": "ser_cabkj4jeu8be3rap4g"
+            "$ref": "#/components/schemas/seriesId"
           },
           "name": {
-            "description": "The name of the series.",
-            "type": "string",
-            "example": "Sword of Truth"
+            "$ref": "#/components/schemas/seriesName"
           },
           "sequence": {
             "description": "The position in the series the book is.",
@@ -1341,8 +1512,7 @@
                 "example": "audio/mpeg"
               },
               "size": {
-                "type": "integer",
-                "example": 23653735
+                "$ref": "#/components/schemas/size"
               }
             }
           },
@@ -1368,9 +1538,7 @@
             "example": false
           },
           "duration": {
-            "description": "The duration (in seconds) of the RSS feed episode.",
-            "type": "number",
-            "example": 1454.18449
+            "$ref": "#/components/schemas/durationSec"
           },
           "season": {
             "description": "The season of the RSS feed episode.",
@@ -1619,9 +1787,7 @@
             "example": "MP2/3 (MPEG audio layer 2/3)"
           },
           "duration": {
-            "description": "The total length (in seconds) of the audio file.",
-            "type": "number",
-            "example": 6004.6675
+            "$ref": "#/components/schemas/durationSec"
           },
           "bitRate": {
             "description": "The bit rate (in bit/s) of the audio file.",
@@ -1693,9 +1859,7 @@
             "example": 0
           },
           "duration": {
-            "description": "The length (in seconds) of the audio track.",
-            "type": "number",
-            "example": 33854.905
+            "$ref": "#/components/schemas/durationSec"
           },
           "title": {
             "description": "The filename of the audio file the audio track belongs to.",
@@ -1782,6 +1946,7 @@
       },
       "folderId": {
         "type": "string",
+        "description": "Folder ID",
         "anyOf": [
           {
             "$ref": "#/components/schemas/oldFolderId"
@@ -1793,6 +1958,7 @@
       },
       "folder": {
         "type": "object",
+        "description": "Folder used in library",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/folderId"
@@ -1807,11 +1973,11 @@
               "$ref": "#/components/schemas/libraryId"
             }
           ],
-          "addedAt": {
-            "description": "The time (in ms since POSIX epoch) when the folder was added. (Read Only)",
-            "type": "integer",
-            "example": 1650462940610
-          }
+          "addedAt": [
+            {
+              "$ref": "#/components/schemas/addedAt"
+            }
+          ]
         }
       },
       "oldLibraryId": {
@@ -1858,7 +2024,8 @@
           "displayOrder": {
             "type": "integer",
             "description": "Display position of the library in the list of libraries. Must be >= 1.",
-            "example": 1
+            "example": 1,
+            "minimum": 1
           },
           "icon": {
             "type": "string",
@@ -1916,12 +2083,10 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "string",
-                  "example": "ser_cabkj4jeu8be3rap4g"
+                  "$ref": "#/components/schemas/seriesId"
                 },
                 "name": {
-                  "type": "string",
-                  "example": "Sword of Truth"
+                  "$ref": "#/components/schemas/seriesName"
                 }
               }
             }
@@ -1968,6 +2133,7 @@
       },
       "libraryItemBase": {
         "type": "object",
+        "description": "Base library item schema",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/libraryItemId"
@@ -2021,11 +2187,9 @@
             "description": "Whether the library item was scanned and no longer has media files.",
             "type": "boolean"
           },
-          "mediaType": [
-            {
-              "$ref": "#/components/schemas/mediaType"
-            }
-          ]
+          "mediaType": {
+            "$ref": "#/components/schemas/mediaType"
+          }
         }
       },
       "libraryItem": {
@@ -2111,24 +2275,18 @@
                 }
               },
               "size": {
-                "description": "The total size (in bytes) of the library item.",
-                "type": "integer",
-                "example": 268990279
+                "$ref": "#/components/schemas/size"
               }
             }
           }
         ]
       },
-      "book": {
+      "bookBase": {
         "type": "object",
+        "description": "Base book schema",
         "properties": {
           "libraryItemId": {
-            "description": "The ID of the library item that contains the book.",
-            "type": "string",
-            "example": "li_8gch9ve09orgn4fdz8"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/bookMetadata"
+            "$ref": "#/components/schemas/libraryItemId"
           },
           "coverPath": {
             "description": "The absolute path on the server of the cover file. Will be null if there is no cover.",
@@ -2165,8 +2323,26 @@
           }
         }
       },
+      "book": {
+        "type": "object",
+        "description": "Book schema, contains information about the book library item.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bookBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "$ref": "#/components/schemas/bookMetadata"
+              }
+            }
+          }
+        ]
+      },
       "bookMinified": {
         "type": "object",
+        "description": "Minified book schema. Does not depend on `bookBase` because there's pretty much no overlap.",
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/bookMetadataMinified"
@@ -2208,14 +2384,10 @@
             "example": 0
           },
           "duration": {
-            "description": "The total length (in seconds) of the book.",
-            "type": "number",
-            "example": 33854.905
+            "$ref": "#/components/schemas/durationSec"
           },
           "size": {
-            "description": "The total size (in bytes) of the book.",
-            "type": "integer",
-            "example": 268824228
+            "$ref": "#/components/schemas/size"
           },
           "ebookFormat": {
             "description": "The format of ebook of the book. Will be null if the book is an audiobook.",
@@ -2228,65 +2400,32 @@
       },
       "bookExpanded": {
         "type": "object",
-        "properties": {
-          "libraryItemId": {
-            "description": "The ID of the library item that contains the book.",
-            "type": "string",
-            "example": "li_8gch9ve09orgn4fdz8"
+        "description": "Expanded book object. Adds the duration and size of book, along with audio tracks for the book.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bookBase"
           },
-          "metadata": {
-            "$ref": "#/components/schemas/bookMetadataExpanded"
-          },
-          "coverPath": {
-            "description": "The absolute path on the server of the cover file. Will be null if there is no cover.",
-            "type": [
-              "string",
-              "null"
-            ],
-            "example": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg"
-          },
-          "tags": {
-            "$ref": "#/components/schemas/tags"
-          },
-          "audioFiles": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/audioFile"
-            }
-          },
-          "chapters": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/bookChapter"
-            }
-          },
-          "missingParts": {
-            "description": "Any parts missing from the book by track index.",
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
-          },
-          "ebookFile": {
-            "$ref": "#/components/schemas/ebookFile"
-          },
-          "duration": {
-            "description": "The total length (in seconds) of the book.",
-            "type": "integer",
-            "example": 33854.905
-          },
-          "size": {
-            "description": "The total size (in bytes) of the book.",
-            "type": "integer",
-            "example": 268824228
-          },
-          "tracks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/audioTrack"
+          {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "$ref": "#/components/schemas/bookMetadataExpanded"
+              },
+              "duration": {
+                "$ref": "#/components/schemas/durationSec"
+              },
+              "size": {
+                "$ref": "#/components/schemas/size"
+              },
+              "tracks": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/audioTrack"
+                }
+              }
             }
           }
-        }
+        ]
       },
       "mediaType": {
         "type": "string",
@@ -2297,7 +2436,7 @@
         ]
       },
       "media": {
-        "description": "The media of the library item.",
+        "description": "The media of the library item, contains the book or podcast object.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/book"
@@ -2376,6 +2515,7 @@
       },
       "podcastBase": {
         "type": "object",
+        "description": "Base podcast schema",
         "properties": {
           "coverPath": {
             "description": "The absolute path on the server of the cover file. Will be null if there is no cover.",
@@ -2444,6 +2584,7 @@
       },
       "podcastMinified": {
         "type": "object",
+        "description": "A podcast on the server, minified schema",
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/podcastMetadataMinified"
@@ -2490,14 +2631,13 @@
             "example": 3
           },
           "size": {
-            "description": "The total size (in bytes) of the podcast.",
-            "type": "integer",
-            "example": 23706728
+            "$ref": "#/components/schemas/size"
           }
         }
       },
       "podcastExpanded": {
         "type": "object",
+        "description": "A podcast on the server, expanded schema",
         "properties": {
           "libraryItemId": {
             "$ref": "#/components/schemas/libraryItemId"
@@ -2549,9 +2689,7 @@
             "example": 3
           },
           "size": {
-            "description": "The total size (in bytes) of the podcast.",
-            "type": "integer",
-            "example": 23706728
+            "$ref": "#/components/schemas/size"
           }
         }
       },
@@ -2944,14 +3082,10 @@
                 "$ref": "#/components/schemas/audioTrack"
               },
               "duration": {
-                "description": "The total length (in seconds) of the podcast episode.",
-                "type": "number",
-                "example": 1454.18449
+                "$ref": "#/components/schemas/durationSec"
               },
               "size": {
-                "description": "The total size (in bytes) of the podcast episode.",
-                "type": "integer",
-                "example": 23653735
+                "$ref": "#/components/schemas/size"
               }
             }
           }
@@ -2982,7 +3116,10 @@
         }
       },
       "podcastEpisodeDownload": {
-        "type": "object",
+        "type": [
+          "object",
+          "null"
+        ],
         "properties": {
           "id": {
             "$ref": "#/components/schemas/podcastEpisodeDownloadId"
@@ -3268,6 +3405,14 @@
           }
         }
       },
+      "narrators": {
+        "description": "The narrators of the audiobook.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "example": "Sam Tsoutsouvas"
+        }
+      },
       "bookMetadataBase": {
         "type": "object",
         "properties": {
@@ -3372,12 +3517,7 @@
                 }
               },
               "narrators": {
-                "description": "The narrators of the audiobook.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "example": "Sam Tsoutsouvas"
-                }
+                "$ref": "#/components/schemas/narrators"
               },
               "series": {
                 "description": "The series the book belongs to.",
@@ -3470,12 +3610,7 @@
                 }
               },
               "narrators": {
-                "description": "The narrators of the audiobook.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "example": "Sam Tsoutsouvas"
-                }
+                "$ref": "#/components/schemas/narrators"
               },
               "series": {
                 "description": "The series the book belongs to.",
@@ -3540,9 +3675,7 @@
             "example": "Wizards First Rule 01.mp3"
           },
           "size": {
-            "description": "The size (in bytes) of the file.",
-            "type": "integer",
-            "example": 48037888
+            "$ref": "#/components/schemas/size"
           },
           "mtimeMs": {
             "description": "The time (in ms since POSIX epoch) when the file was last modified on disk.",
@@ -3830,9 +3963,7 @@
             "example": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg"
           },
           "duration": {
-            "description": "The total duration (in seconds) of the playing item.",
-            "type": "number",
-            "example": 1454.18449
+            "$ref": "#/components/schemas/durationSec"
           },
           "playMethod": {
             "description": "What play method the playback session is using. See below for values.",
@@ -4832,6 +4963,32 @@
             "description": "Whether the user can access explicit content.",
             "type": "boolean",
             "example": true
+          }
+        }
+      }
+    },
+    "responses": {
+      "library200": {
+        "description": "OK",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/library"
+            }
+          }
+        }
+      },
+      "ok200": {
+        "description": "OK"
+      },
+      "library404": {
+        "description": "Library not found or user does not have access to library.",
+        "content": {
+          "text/html": {
+            "schema": {
+              "type": "string",
+              "example": "Not found"
+            }
           }
         }
       }

--- a/build-docs/swagger-output.json
+++ b/build-docs/swagger-output.json
@@ -405,6 +405,66 @@
       }
     },
     "/api/libraries": {
+      "post": {
+        "operationId": "createLibrary",
+        "summary": "Create a library with the specified name",
+        "tags": [
+          "Libraries"
+        ],
+        "requestBody": {
+          "description": "Data used to create the new library",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "folders"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "My Audiobook Library"
+                  },
+                  "folders": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/folder"
+                    }
+                  },
+                  "icon": {
+                    "type": "string",
+                    "description": "The icon for the libary.",
+                    "default": "database"
+                  },
+                  "mediaType": {
+                    "type": "string",
+                    "description": "The type of media content for the library",
+                    "enum": [
+                      "book",
+                      "podcast"
+                    ],
+                    "default": "book"
+                  },
+                  "provider": {
+                    "type": "string",
+                    "description": "The default provider for the library",
+                    "default": "google"
+                  },
+                  "settings": {
+                    "$ref": "#/components/schemas/librarySettings"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/library200"
+          }
+        }
+      },
       "get": {
         "operationId": "getAllLibraries",
         "summary": "Get all libraries on server",
@@ -413,14 +473,49 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/library"
-                }
-              }
-            }
+            "$ref": "#/components/responses/library200"
+          }
+        }
+      }
+    },
+    "/api/libraries/{id}": {
+      "get": {
+        "operationId": "getLibraryByID",
+        "summary": "Get a single library by ID on server",
+        "tags": [
+          "Libraries"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/libraryID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/library200"
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteLibraryByID",
+        "summary": "Delete a single library by ID on the server",
+        "tags": [
+          "Libraries"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/libraryID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/library200"
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
           }
         }
       }
@@ -434,13 +529,7 @@
         ],
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "description": "Library ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/libraryID"
           }
         ],
         "responses": {
@@ -595,6 +684,45 @@
     }
   },
   "components": {
+    "parameters": {
+      "libraryID": {
+        "name": "id",
+        "in": "path",
+        "description": "Library ID",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "library200": {
+        "description": "OK",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/library"
+            }
+          }
+        }
+      },
+      "library404": {
+        "description": "Library not found or user does not have access to library.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Not found"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "schemas": {
       "backup": {
         "type": "object",
@@ -1757,38 +1885,6 @@
             "type": "integer",
             "description": "The time (in ms since POSIX epoch) when the library was last updated. (Read Only)",
             "example": 1646520916818
-          }
-        }
-      },
-      "librarySettings": {
-        "type": "object",
-        "properties": {
-          "coverAspectRatio": {
-            "type": "integer",
-            "description": "Whether the library should use square book covers. Must be 0 (for false) or 1 (for true).",
-            "example": 1
-          },
-          "disableWatcher": {
-            "type": "boolean",
-            "description": "Whether to disable the folder watcher for the library.",
-            "example": false
-          },
-          "skipMatchingMediaWithAsin": {
-            "type": "boolean",
-            "description": "Whether to skip matching books that already have an ASIN.",
-            "example": false
-          },
-          "skipMatchingMediaWithIsbn": {
-            "type": "boolean",
-            "description": "Whether to skip matching books that already have an ISBN.",
-            "example": false
-          },
-          "autoScanCronExpression": {
-            "description": "The cron expression for when to automatically scan the library folders. If null, automatic scanning will be disabled.",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         }
       },
@@ -3740,7 +3836,9 @@
           },
           "playMethod": {
             "description": "What play method the playback session is using. See below for values.",
-            "$ref": "#/components/schemas/playMethod"
+            "type": {
+              "$ref": "#/components/schemas/playMethod"
+            }
           },
           "mediaPlayer": {
             "description": "The given media player when the playback session was requested.",
@@ -4000,6 +4098,43 @@
                 }
               ]
             }
+          }
+        }
+      },
+      "librarySettings": {
+        "type": "object",
+        "properties": {
+          "coverAspectRatio": {
+            "type": "integer",
+            "description": "Whether the library should use square book covers. Must be 0 (for false) or 1 (for true).",
+            "default": 1,
+            "example": 1
+          },
+          "disableWatcher": {
+            "type": "boolean",
+            "description": "Whether to disable the folder watcher for the library.",
+            "default": false,
+            "example": false
+          },
+          "skipMatchingMediaWithAsin": {
+            "type": "boolean",
+            "description": "Whether to skip matching books that already have an ASIN.",
+            "default": false,
+            "example": false
+          },
+          "skipMatchingMediaWithIsbn": {
+            "type": "boolean",
+            "description": "Whether to skip matching books that already have an ISBN.",
+            "default": false,
+            "example": false
+          },
+          "autoScanCronExpression": {
+            "description": "The cron expression for when to automatically scan the library folders. If null, automatic scanning will be disabled.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -22,9 +22,83 @@ const libraryFilters = require('../utils/queries/libraryFilters')
 const libraryItemsPodcastFilters = require('../utils/queries/libraryItemsPodcastFilters')
 const authorFilters = require('../utils/queries/authorFilters')
 
+/**
+ * @openapi
+ * components:
+ *   parameters:
+ *     libraryID:
+ *       name: id
+ *       in: path
+ *       description: Library ID
+ *       required: true
+ *       schema:
+ *         type: string
+ *   responses: 
+ *     library200:
+ *       description: OK
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/library'
+ *     library404:
+ *       description: Library not found or user does not have access to library.
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               message:
+ *                 type: string
+ *                 example: Not found
+ */
+
 class LibraryController {
   constructor() { }
 
+  /**
+   * @openapi
+   * /api/libraries:
+   *   post:
+   *     operationId: createLibrary
+   *     summary: Create a library with the specified name
+   *     tags:
+   *       - Libraries
+   *     requestBody:
+   *       description: Data used to create the new library
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - name
+   *               - folders
+   *             properties:
+   *               name:
+   *                 type: string
+   *                 example: My Audiobook Library
+   *               folders:
+   *                 type: array
+   *                 items:
+   *                   $ref: '#/components/schemas/folder'
+   *               icon:
+   *                 type: string
+   *                 description: The icon for the libary.
+   *                 default: database
+   *               mediaType:
+   *                 type: string
+   *                 description: The type of media content for the library
+   *                 enum: [book, podcast]
+   *                 default: book
+   *               provider:
+   *                 type: string
+   *                 description: The default provider for the library
+   *                 default: google
+   *               settings:
+   *                 $ref: '#/components/schemas/librarySettings'
+   *     responses:
+   *       200:
+   *         $ref: '#/components/responses/library200'
+   */
   async create(req, res) {
     const newLibraryPayload = {
       ...req.body
@@ -89,11 +163,7 @@ class LibraryController {
    *       - Libraries
    *     responses:
    *       200:
-   *         description: OK
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/library'
+   *         $ref: '#/components/responses/library200'
    */
   async findAll(req, res) {
     const libraries = await Database.libraryModel.getAllOldLibraries()
@@ -115,6 +185,22 @@ class LibraryController {
    * 
    * @param {import('express').Request} req 
    * @param {import('express').Response} res 
+   */
+  /**
+   * @openapi
+   * /api/libraries/{id}:
+   *   get:
+   *     operationId: getLibraryByID
+   *     summary: Get a single library by ID on server
+   *     tags:
+   *       - Libraries
+   *     parameters:
+   *       - $ref: '#/components/parameters/libraryID'
+   *     responses:
+   *       200:
+   *         $ref: '#/components/responses/library200'
+   *       404:
+   *         $ref: '#/components/responses/library404'
    */
   async findOne(req, res) {
     const includeArray = (req.query.include || '').split(',')
@@ -242,6 +328,22 @@ class LibraryController {
    * Delete a library
    * @param {*} req 
    * @param {*} res 
+   */
+  /**
+   * @openapi
+   * /api/libraries/{id}:
+   *   delete:
+   *     operationId: deleteLibraryByID
+   *     summary: Delete a single library by ID on the server
+   *     tags:
+   *       - Libraries
+   *     parameters:
+   *       - $ref: '#/components/parameters/libraryID'
+   *     responses:
+   *       200:
+   *         $ref: '#/components/responses/library200'
+   *       404:
+   *         $ref: '#/components/responses/library404'
    */
   async delete(req, res) {
     const library = req.library
@@ -539,12 +641,7 @@ class LibraryController {
    *     tags:
    *       - Library
    *     parameters:
-   *       - name: id
-   *         in: path
-   *         description: Library ID
-   *         required: true
-   *         schema:
-   *           type: string
+   *       - $ref: '#/components/parameters/libraryID'
    *     responses:
    *       200:
    *         description: Collection created successfully

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -33,6 +33,35 @@ const authorFilters = require('../utils/queries/authorFilters')
  *       required: true
  *       schema:
  *         type: string
+ *     librarySortBy:
+ *       name: sortBy
+ *       in: query
+ *       description: Sort media items by a specific field
+ *       schema:
+ *         type: string
+ *     librarySortDesc:
+ *       name: sortDesc
+ *       in: query
+ *       description: Whether to sort in descending order
+ *       schema:
+ *         type: boolean
+ *     libraryLimit:
+ *       name: limit
+ *       in: query
+ *       description: Maximum number of items to return. If `0`, no limit will be applied.
+ *       schema:
+ *         type: integer
+ *     libraryPage:
+ *       name: page
+ *       in: query
+ *       description: Page number for pagination. Only applies if a limit has been set.
+ *       schema:
+ *         type: integer
+ *   schemas:
+ *     resultsTotal:
+ *       description: How many results were returned
+ *       type: integer
+ *       minimum: 0
  *   responses: 
  *     library200:
  *       description: OK
@@ -40,16 +69,15 @@ const authorFilters = require('../utils/queries/authorFilters')
  *         application/json:
  *           schema:
  *             $ref: '#/components/schemas/library'
+ *     ok200:
+ *       description: OK
  *     library404:
  *       description: Library not found or user does not have access to library.
  *       content:
- *         application/json:
+ *         text/html:
  *           schema:
- *             type: object
- *             properties:
- *               message:
- *                 type: string
- *                 example: Not found
+ *             type: string
+ *             example: Not found
  */
 
 class LibraryController {
@@ -224,6 +252,33 @@ class LibraryController {
    * Get podcast episodes in download queue
    * @param {*} req 
    * @param {*} res 
+   */
+  /**
+   * @openapi
+   * /api/libraries/{id}/episode-downloads:
+   *   get:
+   *     operationId: getEpisodeDownloadsByLibrary
+   *     summary: Get the episode downloads for a single library by ID
+   *     tags:
+   *       - Libraries
+   *     parameters:
+   *       - $ref: '#/components/parameters/libraryID'
+   *     responses:
+   *       200:
+   *         description: OK
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 currentDownload:
+   *                   $ref: '#/components/schemas/podcastEpisodeDownload'
+   *                 queue:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/podcastEpisodeDownload'
+   *       404:
+   *         $ref: '#/components/responses/library404'
    */
   async getEpisodeDownloadQueue(req, res) {
     const libraryDownloadQueueDetails = this.podcastManager.getDownloadQueueDetails(req.library.id)
@@ -409,37 +464,24 @@ class LibraryController {
    * @param {import('express').Response} res 
    */
   /**
+   * @openapi
    * /api/libraries/{id}/items:
    *   get:
+   *     operationId: getLibraryItemsFromLibrary
    *     summary: Get media items
    *     parameters:
+   *       - $ref: '#/components/parameters/libraryID'
+   *       - $ref: '#/components/parameters/librarySortBy'
+   *       - $ref: '#/components/parameters/librarySortDesc'
+   *       - $ref: '#/components/parameters/libraryLimit'
+   *       - $ref: '#/components/parameters/libraryPage'
    *       - name: filterBy
    *         in: query
    *         description: Filter media items by author
    *         schema:
    *           type: string
-   *       - name: sortBy
-   *         in: query
-   *         description: Sort media items by a specific field
-   *         schema:
-   *           type: string
-   *       - name: sortDesc
-   *         in: query
-   *         description: Whether to sort in descending order
-   *         schema:
-   *           type: boolean
-   *       - name: limit
-   *         in: query
-   *         description: Maximum number of items to return
-   *         schema:
-   *           type: integer
-   *       - name: page
-   *         in: query
-   *         description: Page number for pagination
-   *         schema:
-   *           type: integer
    *     responses:
-   *       '200':
+   *       200:
    *         description: Successful response
    *         content:
    *           application/json:
@@ -448,10 +490,11 @@ class LibraryController {
    *               properties:
    *                 results:
    *                   type: array
+   *                   description: Array of library items
    *                   items:
-   *                     $ref: '#/components/schemas/MediaItem'
+   *                     $ref: '#/components/schemas/libraryItem'
    *                 total:
-   *                   type: integer
+   *                   $ref: '#/components/schemas/resultsTotal'
    *                 limit:
    *                   type: integer
    *                 page:
@@ -463,7 +506,7 @@ class LibraryController {
    *                 filterBy:
    *                   type: string
    *                 mediaType:
-   *                   type: string
+   *                   $ref: '#/components/schemas/mediaType'
    *                 minified:
    *                   type: boolean
    *                 collapseseries:
@@ -507,6 +550,22 @@ class LibraryController {
    * Remove all library items missing or invalid
    * @param {import('express').Request} req 
    * @param {import('express').Response} res 
+   */
+  /**
+   * @openapi
+   * /api/libraries/{id}/issues:
+   *   delete:
+   *     operationId: deleteLibraryIssuesByID
+   *     summary: Remove all library items that have issues in the given library.
+   *     tags:
+   *       - Libraries
+   *     parameters:
+   *       - $ref: '#/components/parameters/libraryID'
+   *     responses:
+   *       200:
+   *         $ref: '#/components/responses/ok200'
+   *       404:
+   *         $ref: '#/components/responses/library404'
    */
   async removeLibraryItemsWithIssues(req, res) {
     const libraryItemsWithIssues = await Database.libraryItemModel.findAll({

--- a/server/objects/Backup.js
+++ b/server/objects/Backup.js
@@ -38,9 +38,7 @@ const version = require('../../package.json').version
  *           type: string
  *           example: 2022-11-14T0130.audiobookshelf
  *         fileSize:
- *           description: The size (in bytes) of the backup file.
- *           type: integer
- *           example: 7776983
+ *           $ref: '#/components/schemas/size'
  *         createdAt:
  *           $ref: '#/components/schemas/createdAt'
  *         serverVersion:

--- a/server/objects/FeedEpisode.js
+++ b/server/objects/FeedEpisode.js
@@ -45,8 +45,7 @@ const { secondsToTimestamp } = require('../utils/index')
  *               type: string
  *               example: audio/mpeg
  *             size:
- *               type: integer
- *               example: 23653735
+ *               $ref: '#/components/schemas/size'
  *         pubDate:
  *           description: The RSS feed episode's publication date.
  *           type: string

--- a/server/objects/FeedEpisode.js
+++ b/server/objects/FeedEpisode.js
@@ -64,9 +64,7 @@ const { secondsToTimestamp } = require('../utils/index')
  *           type: boolean
  *           example: false
  *         duration:
- *           description: The duration (in seconds) of the RSS feed episode.
- *           type: number
- *           example: 1454.18449
+ *           $ref: '#/components/schemas/durationSec'
  *         season:
  *           description: The season of the RSS feed episode.
  *           type: [string, 'null']

--- a/server/objects/Folder.js
+++ b/server/objects/Folder.js
@@ -16,11 +16,13 @@ const uuidv4 = require("uuid").v4
  *       example: e4bb1afb-4a4f-4dd6-8be0-e615d233185b
  *     folderId:
  *       type: string
+ *       description: Folder ID
  *       anyOf:
  *         - $ref: '#/components/schemas/oldFolderId'
  *         - $ref: '#/components/schemas/newFolderId'
  *     folder:
  *       type: object
+ *       description: Folder used in library
  *       properties:
  *         id:
  *           $ref: '#/components/schemas/folderId'
@@ -31,9 +33,7 @@ const uuidv4 = require("uuid").v4
  *         libraryId:
  *           - $ref: '#/components/schemas/libraryId'
  *         addedAt:
- *           description: The time (in ms since POSIX epoch) when the folder was added. (Read Only)
- *           type: integer
- *           example: 1650462940610
+ *           - $ref: '#/components/schemas/addedAt'
  */
 class Folder {
   constructor(folder = null) {

--- a/server/objects/Library.js
+++ b/server/objects/Library.js
@@ -57,28 +57,6 @@ const { filePathToPOSIX } = require('../utils/fileUtils')
  *           type: integer
  *           description: The time (in ms since POSIX epoch) when the library was last updated. (Read Only)
  *           example: 1646520916818
- *     librarySettings:
- *       type: object
- *       properties:
- *         coverAspectRatio:
- *           type: integer
- *           description: Whether the library should use square book covers. Must be 0 (for false) or 1 (for true).
- *           example: 1
- *         disableWatcher:
- *           type: boolean
- *           description: Whether to disable the folder watcher for the library.
- *           example: false
- *         skipMatchingMediaWithAsin:
- *           type: boolean
- *           description: Whether to skip matching books that already have an ASIN.
- *           example: false
- *         skipMatchingMediaWithIsbn:
- *           type: boolean
- *           description: Whether to skip matching books that already have an ISBN.
- *           example: false
- *         autoScanCronExpression:
- *           description: The cron expression for when to automatically scan the library folders. If null, automatic scanning will be disabled.
- *           type: [string, 'null']
  *     libraryFilterData:
  *       type: object
  *       properties:

--- a/server/objects/Library.js
+++ b/server/objects/Library.js
@@ -39,6 +39,7 @@ const { filePathToPOSIX } = require('../utils/fileUtils')
  *           type: integer
  *           description: Display position of the library in the list of libraries. Must be >= 1.
  *           example: 1
+ *           minimum: 1
  *         icon:
  *           type: string
  *           description: The selected icon for the library. See [Library Icons](https://api.audiobookshelf.org/#library-icons) for a list of possible icons.
@@ -80,11 +81,9 @@ const { filePathToPOSIX } = require('../utils/fileUtils')
  *             type: object
  *             properties:
  *               id:
- *                 type: string
- *                 example: ser_cabkj4jeu8be3rap4g
+ *                 $ref: '#/components/schemas/seriesId'
  *               name:
- *                 type: string
- *                 example: Sword of Truth
+ *                 $ref: '#/components/schemas/seriesName'
  *         narrators:
  *           description: The narrators of books in the library.
  *           type: array

--- a/server/objects/LibraryItem.js
+++ b/server/objects/LibraryItem.js
@@ -26,11 +26,12 @@ const { filePathToPOSIX, getFileTimestampsWithIno } = require('../utils/fileUtil
  *       example: e4bb1afb-4a4f-4dd6-8be0-e615d233185b
  *     libraryItemId:
  *       type: string
- *       oneOf:
+ *       anyOf:
  *         - $ref: '#/components/schemas/oldLibraryItemId'
  *         - $ref: '#/components/schemas/newLibraryItemId'
  *     libraryItemBase:
  *       type: object
+ *       description: Base library item schema
  *       properties:
  *         id:
  *           $ref: '#/components/schemas/libraryItemId'
@@ -125,9 +126,7 @@ const { filePathToPOSIX, getFileTimestampsWithIno } = require('../utils/fileUtil
  *               items:
  *                 $ref: '#/components/schemas/libraryFile'
  *             size:
- *               description: The total size (in bytes) of the library item.
- *               type: integer
- *               example: 268990279
+ *               $ref: '#/components/schemas/size'
  */
 class LibraryItem {
   constructor(libraryItem = null) {

--- a/server/objects/LibraryItem.js
+++ b/server/objects/LibraryItem.js
@@ -26,7 +26,7 @@ const { filePathToPOSIX, getFileTimestampsWithIno } = require('../utils/fileUtil
  *       example: e4bb1afb-4a4f-4dd6-8be0-e615d233185b
  *     libraryItemId:
  *       type: string
- *       anyOf:
+ *       oneOf:
  *         - $ref: '#/components/schemas/oldLibraryItemId'
  *         - $ref: '#/components/schemas/newLibraryItemId'
  *     libraryItemBase:
@@ -71,12 +71,12 @@ const { filePathToPOSIX, getFileTimestampsWithIno } = require('../utils/fileUtil
  *           description: Whether the library item was scanned and no longer has media files.
  *           type: boolean
  *         mediaType:
- *           - $ref: '#/components/schemas/mediaType'
+ *           $ref: '#/components/schemas/mediaType'
  *     libraryItem:
  *       type: object
  *       description: A single item on the server, like a book or podcast.
  *       allOf:
- *         - $ref : '#/components/schemas/libraryItemBase'
+ *         - $ref: '#/components/schemas/libraryItemBase'
  *         - type: object
  *           properties:
  *             folderId:

--- a/server/objects/PlaybackSession.js
+++ b/server/objects/PlaybackSession.js
@@ -84,9 +84,7 @@ const VideoMetadata = require('./metadata/VideoMetadata')
  *           type: string
  *           example: /metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg
  *         duration:
- *           description: The total duration (in seconds) of the playing item.
- *           type: number
- *           example: 1454.18449
+ *           $ref: '#/components/schemas/durationSec'
  *         playMethod:
  *           description: What play method the playback session is using. See below for values.
  *           type:

--- a/server/objects/PlaybackSession.js
+++ b/server/objects/PlaybackSession.js
@@ -89,7 +89,8 @@ const VideoMetadata = require('./metadata/VideoMetadata')
  *           example: 1454.18449
  *         playMethod:
  *           description: What play method the playback session is using. See below for values.
- *           $ref: '#/components/schemas/playMethod'
+ *           type:
+ *             $ref: '#/components/schemas/playMethod'
  *         mediaPlayer:
  *           description: The given media player when the playback session was requested.
  *           type: string

--- a/server/objects/components.js
+++ b/server/objects/components.js
@@ -23,4 +23,8 @@
  *         - Favorite
  *         - Nonfiction/History
  *         - Content: Violence
+ *     size:
+ *       description: The total size (in bytes) of the item or file.
+ *       type: integer
+ *       example: 268824228
  */

--- a/server/objects/components.js
+++ b/server/objects/components.js
@@ -27,4 +27,8 @@
  *       description: The total size (in bytes) of the item or file.
  *       type: integer
  *       example: 268824228
+ *     durationSec:
+ *       description: The total length (in seconds) of the item or file.
+ *       type: number
+ *       example: 33854.905
  */

--- a/server/objects/entities/Series.js
+++ b/server/objects/entities/Series.js
@@ -5,17 +5,33 @@ const { getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index
  * @openapi
  * components:
  *   schemas:
+ *     oldSeriesId:
+ *       description: The ID of series on server version 2.2.23 and before.
+ *       type: string
+ *       format: "ser_[a-z0-9]{18}"
+ *       example: ser_o78uaoeuh78h6aoeif
+ *     newSeriesId:
+ *       type: string
+ *       description: The ID of series after 2.3.0.
+ *       format: uuid
+ *       example: e4bb1afb-4a4f-4dd6-8be0-e615d233185b
+ *     seriesId:
+ *       type: string
+ *       description: The ID of the series.
+ *       anyOf:
+ *         - $ref: '#/components/schemas/oldSeriesId'
+ *         - $ref: '#/components/schemas/newSeriesId'
+ *     seriesName:
+ *       description: The name of the series.
+ *       type: string
+ *       example: Sword of Truth
  *     series:
  *       type: object
  *       properties:
  *         id:
- *           description: The ID of the series.
- *           type: string
- *           example: ser_cabkj4jeu8be3rap4g
+ *           $ref: '#/components/schemas/seriesId'
  *         name:
- *           description: The name of the series.
- *           type: string
- *           example: Sword of Truth
+ *           $ref: '#/components/schemas/seriesName'
  *         description:
  *           description: A description for the series. Will be null if there is none.
  *           type: [string, 'null']
@@ -27,13 +43,9 @@ const { getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index
  *       type: object
  *       properties:
  *         id:
- *           description: The ID of the series.
- *           type: string
- *           example: ser_cabkj4jeu8be3rap4g
+ *           $ref: '#/components/schemas/seriesId'
  *         name:
- *           description: The name of the series.
- *           type: string
- *           example: Sword of Truth
+ *           $ref: '#/components/schemas/seriesName'
  *         nameIgnorePrefix:
  *           description: The name of the series with any prefix moved to the end.
  *           type: string
@@ -42,8 +54,7 @@ const { getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index
  *           description: The IDs of the library items in the series.
  *           type: array
  *           items:
- *             type: string
- *             example: li_8gch9ve09orgn4fdz8
+ *             $ref: '#/components/schemas/libraryItemId'
  *         numBooks:
  *           description: The number of books in the series.
  *           type: integer
@@ -52,13 +63,9 @@ const { getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index
  *       type: object
  *       properties:
  *         id:
- *           description: The ID of the series.
- *           type: string
- *           example: ser_cabkj4jeu8be3rap4g
+ *           $ref: '#/components/schemas/seriesId'
  *         name:
- *           description: The name of the series.
- *           type: string
- *           example: Sword of Truth
+ *           $ref: '#/components/schemas/seriesName'
  *         nameIgnorePrefix:
  *           description: The name of the series with any prefix moved to the end.
  *           type: string
@@ -77,9 +84,7 @@ const { getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index
  *           items: 
  *             $ref: '#/components/schemas/libraryItem'
  *         addedAt:
- *           description: The time (in ms since POSIX epoch) when the series was added.
- *           type: integer
- *           example: 1650621073750
+ *           $ref: '#/components/schemas/addedAt'
  *         totalDuration:
  *           description: The combined duration (in seconds) of all books in the series.
  *           type: number
@@ -88,13 +93,9 @@ const { getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index
  *       type: object
  *       properties:
  *         id:
- *           description: The ID of the series.
- *           type: string
- *           example: ser_cabkj4jeu8be3rap4g
+ *           $ref: '#/components/schemas/seriesId'
  *         name:
- *           description: The name of the series.
- *           type: string
- *           example: Sword of Truth
+ *           $ref: '#/components/schemas/seriesName'
  *         sequence:
  *           description: The position in the series the book is.
  *           type: string

--- a/server/objects/files/AudioFile.js
+++ b/server/objects/files/AudioFile.js
@@ -57,9 +57,7 @@ const FileMetadata = require('../metadata/FileMetadata')
  *           type: string
  *           example: MP2/3 (MPEG audio layer 2/3)
  *         duration:
- *           description: The total length (in seconds) of the audio file.
- *           type: number
- *           example: 6004.6675
+ *           $ref: '#/components/schemas/durationSec'
  *         bitRate:
  *           description: The bit rate (in bit/s) of the audio file.
  *           type: integer

--- a/server/objects/files/AudioTrack.js
+++ b/server/objects/files/AudioTrack.js
@@ -14,9 +14,7 @@
  *           type: number
  *           example: 0
  *         duration:
- *           description: The length (in seconds) of the audio track.
- *           type: number
- *           example: 33854.905
+ *           $ref: '#/components/schemas/durationSec'
  *         title:
  *           description: The filename of the audio file the audio track belongs to.
  *           type: string

--- a/server/objects/mediaTypes/Book.js
+++ b/server/objects/mediaTypes/Book.js
@@ -10,15 +10,12 @@ const EBookFile = require('../files/EBookFile')
  * @openapi
  * components:
  *   schemas:
- *     book:
+ *     bookBase:
  *       type: object
+ *       description: Base book schema
  *       properties:
  *         libraryItemId:
- *           description: The ID of the library item that contains the book.
- *           type: string
- *           example: li_8gch9ve09orgn4fdz8
- *         metadata:
- *           $ref: '#/components/schemas/bookMetadata'
+ *           $ref: '#/components/schemas/libraryItemId'
  *         coverPath:
  *           description: The absolute path on the server of the cover file. Will be null if there is no cover.
  *           type: [string, 'null']
@@ -40,8 +37,18 @@ const EBookFile = require('../files/EBookFile')
  *             type: integer
  *         ebookFile:
  *           $ref: '#/components/schemas/ebookFile'
+ *     book:
+ *       type: object
+ *       description: Book schema, contains information about the book library item.
+ *       allOf:
+ *         - $ref: '#/components/schemas/bookBase'
+ *         - type: object
+ *           properties:
+ *             metadata:
+ *               $ref: '#/components/schemas/bookMetadata'
  *     bookMinified:
  *       type: object
+ *       description: Minified book schema. Does not depend on `bookBase` because there's pretty much no overlap.
  *       properties:
  *         metadata:
  *           $ref: '#/components/schemas/bookMetadataMinified'
@@ -72,58 +79,29 @@ const EBookFile = require('../files/EBookFile')
  *           type: integer
  *           example: 0
  *         duration:
- *           description: The total length (in seconds) of the book.
- *           type: number
- *           example: 33854.905
+ *           $ref: '#/components/schemas/durationSec'
  *         size:
- *           description: The total size (in bytes) of the book.
- *           type: integer
- *           example: 268824228
+ *           $ref: '#/components/schemas/size'
  *         ebookFormat:
  *           description: The format of ebook of the book. Will be null if the book is an audiobook.
  *           type: [string, 'null']
  *     bookExpanded:
  *       type: object
- *       properties:
- *         libraryItemId:
- *           description: The ID of the library item that contains the book.
- *           type: string
- *           example: li_8gch9ve09orgn4fdz8
- *         metadata:
- *           $ref: '#/components/schemas/bookMetadataExpanded'
- *         coverPath:
- *           description: The absolute path on the server of the cover file. Will be null if there is no cover.
- *           type: [string, 'null']
- *           example: /audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg
- *         tags:
- *           $ref: '#/components/schemas/tags'
- *         audioFiles:
- *           type: array
- *           items:
- *             $ref: '#/components/schemas/audioFile'
- *         chapters:
- *           type: array
- *           items:
- *             $ref: '#/components/schemas/bookChapter'
- *         missingParts:
- *           description: Any parts missing from the book by track index.
- *           type: array
- *           items:
- *             type: integer
- *         ebookFile:
- *           $ref: '#/components/schemas/ebookFile'
- *         duration:
- *           description: The total length (in seconds) of the book.
- *           type: integer
- *           example: 33854.905
- *         size:
- *           description: The total size (in bytes) of the book.
- *           type: integer
- *           example: 268824228
- *         tracks:
- *           type: array
- *           items:
- *             $ref: '#/components/schemas/audioTrack'
+ *       description: Expanded book object. Adds the duration and size of book, along with audio tracks for the book.
+ *       allOf:
+ *         - $ref: '#/components/schemas/bookBase'
+ *         - type: object
+ *           properties:
+ *             metadata:
+ *               $ref: '#/components/schemas/bookMetadataExpanded'
+ *             duration:
+ *               $ref: '#/components/schemas/durationSec'
+ *             size:
+ *               $ref: '#/components/schemas/size'
+ *             tracks:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/audioTrack'
  */
 class Book {
   constructor(book) {

--- a/server/objects/mediaTypes/Podcast.js
+++ b/server/objects/mediaTypes/Podcast.js
@@ -118,9 +118,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *           type: integer
  *           example: 3
  *         size:
- *           description: The total size (in bytes) of the podcast.
- *           type: integer
- *           example: 23706728
+ *           $ref: '#/components/schemas/size'
  *     podcastExpanded:
  *       type: object
  *       properties:
@@ -160,9 +158,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *           type: integer
  *           example: 3
  *         size:
- *           description: The total size (in bytes) of the podcast.
- *           type: integer
- *           example: 23706728
+ *           $ref: '#/components/schemas/size'
  *     podcastMetadataBase:
  *       type: object
  *       properties:
@@ -468,9 +464,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *               type: number
  *               example: 1454.18449
  *             size:
- *               description: The total size (in bytes) of the podcast episode.
- *               type: integer
- *               example: 23653735
+ *               $ref: '#/components/schemas/size'
  *     podcastEpisodeEnclousure:
  *       type: [object, 'null']
  *       properties:
@@ -489,7 +483,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *           type: string
  *           example: '20588611'
  *     podcastEpisodeDownload:
- *       type: object
+ *       type: [object, 'null']
  *       properties:
  *         id:
  *           $ref: '#/components/schemas/podcastEpisodeDownloadId'

--- a/server/objects/mediaTypes/Podcast.js
+++ b/server/objects/mediaTypes/Podcast.js
@@ -39,6 +39,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *         - $ref: '#/components/schemas/newPodcastEpisodeDownloadId'
  *     podcastBase:
  *       type: object
+ *       description: Base podcast schema
  *       properties:
  *         coverPath:
  *           description: The absolute path on the server of the cover file. Will be null if there is no cover.
@@ -84,6 +85,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *                 $ref: '#/components/schemas/podcastEpisode'
  *     podcastMinified:
  *       type: object
+ *       description: A podcast on the server, minified schema
  *       properties:
  *         metadata:
  *           $ref: '#/components/schemas/podcastMetadataMinified'
@@ -121,6 +123,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *           $ref: '#/components/schemas/size'
  *     podcastExpanded:
  *       type: object
+ *       description: A podcast on the server, expanded schema
  *       properties:
  *         libraryItemId:
  *           $ref: '#/components/schemas/libraryItemId'
@@ -460,9 +463,7 @@ const { filePathToPOSIX } = require('../../utils/fileUtils')
  *             audioTrack:
  *               $ref: '#/components/schemas/audioTrack'
  *             duration:
- *               description: The total length (in seconds) of the podcast episode.
- *               type: number
- *               example: 1454.18449
+ *               $ref: '#/components/schemas/durationSec'
  *             size:
  *               $ref: '#/components/schemas/size'
  *     podcastEpisodeEnclousure:

--- a/server/objects/mediaTypes/media.js
+++ b/server/objects/mediaTypes/media.js
@@ -7,7 +7,7 @@
  *       description: The type of media, will be book or podcast.
  *       enum: [book, podcast]
  *     media:
- *       description: The media of the library item.
+ *       description: The media of the library item, contains the book or podcast object.
  *       oneOf:
  *         - $ref: '#/components/schemas/book'
  *         - $ref: '#/components/schemas/podcast'

--- a/server/objects/metadata/BookMetadata.js
+++ b/server/objects/metadata/BookMetadata.js
@@ -6,6 +6,12 @@ const parseNameString = require('../../utils/parsers/parseNameString')
  * @openapi
  * components:
  *   schemas:
+ *     narrators:
+ *       description: The narrators of the audiobook.
+ *       type: array
+ *       items:
+ *         type: string
+ *         example: Sam Tsoutsouvas
  *     bookMetadataBase:
  *       type: object
  *       properties:
@@ -81,11 +87,7 @@ const parseNameString = require('../../utils/parsers/parseNameString')
  *               items:
  *                 $ref: '#/components/schemas/authorMinified'
  *             narrators:
- *               description: The narrators of the audiobook.
- *               type: array
- *               items:
- *                 type: string
- *                 example: Sam Tsoutsouvas
+ *                 $ref: '#/components/schemas/narrators'
  *             series:
  *               description: The series the book belongs to.
  *               type: array
@@ -149,11 +151,7 @@ const parseNameString = require('../../utils/parsers/parseNameString')
  *               items:
  *                 $ref: '#/components/schemas/authorMinified'
  *             narrators:
- *               description: The narrators of the audiobook.
- *               type: array
- *               items:
- *                 type: string
- *                 example: Sam Tsoutsouvas
+ *                 $ref: '#/components/schemas/narrators'
  *             series:
  *               description: The series the book belongs to.
  *               type: array

--- a/server/objects/metadata/FileMetadata.js
+++ b/server/objects/metadata/FileMetadata.js
@@ -24,9 +24,7 @@
  *           type: string
  *           example: Wizards First Rule 01.mp3
  *         size:
- *           description: The size (in bytes) of the file.
- *           type: integer
- *           example: 48037888
+ *           $ref: '#/components/schemas/size'
  *         mtimeMs:
  *           description: The time (in ms since POSIX epoch) when the file was last modified on disk.
  *           type: integer

--- a/server/objects/settings/LibrarySettings.js
+++ b/server/objects/settings/LibrarySettings.js
@@ -1,5 +1,37 @@
 const { BookCoverAspectRatio } = require('../../utils/constants')
 
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     librarySettings:
+ *       type: object
+ *       properties:
+ *         coverAspectRatio:
+ *           type: integer
+ *           description: Whether the library should use square book covers. Must be 0 (for false) or 1 (for true).
+ *           default: 1
+ *           example: 1
+ *         disableWatcher:
+ *           type: boolean
+ *           description: Whether to disable the folder watcher for the library.
+ *           default: false
+ *           example: false
+ *         skipMatchingMediaWithAsin:
+ *           type: boolean
+ *           description: Whether to skip matching books that already have an ASIN.
+ *           default: false
+ *           example: false
+ *         skipMatchingMediaWithIsbn:
+ *           type: boolean
+ *           description: Whether to skip matching books that already have an ISBN.
+ *           default: false
+ *           example: false
+ *         autoScanCronExpression:
+ *           description: The cron expression for when to automatically scan the library folders. If null, automatic scanning will be disabled.
+ *           default: null
+ *           type: [string, 'null']
+ */
 class LibrarySettings {
   constructor(settings) {
     this.coverAspectRatio = BookCoverAspectRatio.SQUARE


### PR DESCRIPTION
This PR began as adding a number of Library endpoints, but during the process of creating these endpoints I got distracted cleaning up other schemas. My validation is failing somewhere in the Libraries endpoints, so I'm going to hold off on these endpoint definitions and switch back to doing some of the other "simpler" ones to ensure that I get the base schemas defined correctly first, such as `User`, `Author`, `Book`, etc.